### PR TITLE
Changing demos from ES6 promises to RSVP promises

### DIFF
--- a/tests/dummy/app/controllers/emforms.js
+++ b/tests/dummy/app/controllers/emforms.js
@@ -20,7 +20,7 @@ export default Ember.ArrayController.extend({
     return this.set('newUser', this.get('store').createRecord('user'));
   },
   fakePromise: function(objToReturn) {
-    return new Promise(function(res, rej) {
+    return new Ember.RSVP.Promise(function(res, rej) {
       return Ember.run.later(function() {
         return res(objToReturn);
       }, 1500);

--- a/tests/dummy/app/controllers/forms.js
+++ b/tests/dummy/app/controllers/forms.js
@@ -28,7 +28,7 @@ export default Ember.ArrayController.extend({
     }
   },
   fakePromise: function(objToReturn) {
-    return new Promise((function(_this) {
+    return new Ember.RSVP.Promise((function(_this) {
       return function(res, rej) {
         return Ember.run.later(function() {
           _this.set('message', '<b>Form submitted!</b>');


### PR DESCRIPTION
This changes the demo promises from ES6 Promises to RSVP promises to get JS lint to stop complaining, and for compatibility.