### PR TITLE
Allow nested modals

### DIFF
--- a/addon/modal-toggler.js
+++ b/addon/modal-toggler.js
@@ -52,14 +52,14 @@ export default Em.Component.extend(WithConfigMixin, StyleBindingsMixin, {
    * @method modalAsProperty
    */
   modalAsProperty: (function() {
-    var modalAsAncestor;
-    modalAsAncestor = this.nearestOfType(Modal);
-    if (modalAsAncestor) {
-      return this.set('modal', modalAsAncestor);
-    } else {
+    var modalId = this.get('modal-id'); 
+
+    if (modalId) {
       return Em.run.schedule('afterRender', this, function() {
-        return this.set('modal', Em.View.views[this.get('modal-id')]);
+        return this.set('modal', Em.View.views[modalId]);
       });
+    } else {
+      return this.set('modal', this.nearestOfType(Modal));
     }
   }).on('willInsertElement')
 });


### PR DESCRIPTION
In my app I occasionally need to open nested modals. This PR allows that by changing the order of setting the `modal` property for the `modal-toggler` component.

To me it makes more sense to have the `modal-id` field be the default field a `modal-toggler` uses for choosing the target modal as it is explicit, rather than implicit. When we want to add a toggler to a modal to close the modal, we omit the `modal-id` field and everything works as expected. If we want to target another modal, we set the `modal-id` field. No need to include another option.