### PR TITLE
Fixes config singleton usage

### DIFF
--- a/app/initializers/config.js
+++ b/app/initializers/config.js
@@ -5,13 +5,13 @@ export default {
   name: 'ember-idx-modal',
   initialize: function() {
     if (!Em.Config) {
-        Em.Config = Config = Config.create()
+        Em.Config = Config.create()
     }
 
-    var defaultConfig = Config.getConfig('bs');
+    var defaultConfig = Em.Config.getConfig('bs');
     if (!defaultConfig) {
-        Config.addConfig('bs');
-        defaultConfig = Config.getConfig('bs');
+        Em.Config.addConfig('bs');
+        defaultConfig = Em.Config.getConfig('bs');
     }
 
     defaultConfig['modal'] = {


### PR DESCRIPTION
When multiple Indexiatech addons are included in a single app, they check if Em.Config exists in the initializers and if not create it. However, if Em.Config does exist they continue to use the imported Config variable. This variable is the constructor for the config object, not the instance of it created and added to Ember. Errors are thrown by the 2nd, 3rd... etc plugin trying to initialize their configurations.

The solution is to use initialize if it doesn't exist Em.Config and use it exclusively for setting configs.