### PR TITLE
Added reset of submission

### DIFF
--- a/addon/modal-form.js
+++ b/addon/modal-form.js
@@ -53,6 +53,7 @@ export default Modal.extend({
     if (!this.get('submitted')) {
       this.sendAction('on-cancel', this);
     }
+    this.set('submitted', false);
     return this._super.apply(this, arguments);
   }
 });


### PR DESCRIPTION
Hi,

I was using your modals for what I think is a common use case: Editing and creating certain models in the same form. However, a bug occurs from the following sequence:

1. Edit an existing model.
2. Submit (setting `submitted` true on the `ember-forms` component)
3. Create new model (setting model of `modal=this.store.createRecord('model')`)
4. Cancel without saving

As implemented the `submitted` boolean is still true, even though the form hasn't been submitted. I propose a simple and semantic bug fix. As I understand it, `submitted` is used to ensure that the `on-cancel` event is triggered if necessary. Once its been triggered, the boolean *should* be reset to maintain the invariant that it represents the submit status of the current modal. Please agree so I don't have to use a forked version of this otherwise great plugin!
