### PR TITLE
Add option to ignore ESC keyboard events

### DIFF
--- a/addon/modal.js
+++ b/addon/modal.js
@@ -201,14 +201,23 @@ export default Em.Component.extend(WithConfigMixin, StyleBindingsMixin, {
   }).on('click'),
 
   /**
+   * Parameter set to true to ignore ESC keyboard event
+   * @property ignore-esc
+   * @private
+   */
+  'ignore-esc': false,
+
+  /**
    * Handle keyboard events
    * @method handleKeyboard
    * @private
    */
   handleKeyboard: (function(e) {
-    switch (e.keyCode) {
-      case 27:
-        return this.close();
+    if (!this.get('ignore-esc')) {
+      switch (e.keyCode) {
+        case 27:
+          return this.close();
+      }
     }
   }).on('keyDown'),
 


### PR DESCRIPTION
This is useful to me for modals that have components using these events (e.g. custom form inputs). Hope it can help others. Usage is simple: add `ignore-esc=true` to `em-modal` helper.